### PR TITLE
フォルダ表示機能「ログインしたidのフォルダのみを表示」

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -14,7 +14,8 @@ class TaskController extends Controller
     public function index(int $id)
     {
         // すべてのフォルダを取得する
-        $folders = Folder::all();
+        // $folders = Folder::all();
+        $folders = Auth::user()->folders()->get();
     
         // 選ばれたフォルダを取得する
         $current_folder = Folder::find($id);


### PR DESCRIPTION
ログインした際に全てのフォルダを獲得してしまっていたため、ログインid
に該当するものに絞る修正をいたしました。